### PR TITLE
delete an odd improper term for CPRO

### DIFF
--- a/Gromacs_FFs/a99SBdisp.ff/aminoacids.rtp
+++ b/Gromacs_FFs/a99SBdisp.ff/aminoacids.rtp
@@ -2605,8 +2605,7 @@
      C   OC2
     -C     N
  [ impropers ]
-    -C     N     CA    C    90.0        1.67360    2 
-    CA   OC1     C   OC2    
+    CA   OC1     C   OC2
     -C    CD     N    CA    
                         
 [ CCYS ]


### PR DESCRIPTION
Desmond does not have an odd improper term for CPRO. Hence, it looks like a bug in Gromacs rendition of ff99SB-disp.