### PR TITLE
Update ffbonded.itp

### DIFF
--- a/Gromacs_FFs/a99SBdisp.ff/ffbonded.itp
+++ b/Gromacs_FFs/a99SBdisp.ff/ffbonded.itp
@@ -496,6 +496,7 @@
  CT  CV  CC  NA    4     180.0      4.60240     2  ; Amber99Sb-disp
  CT  CW  CC  NB    4     180.0      4.60240     2  ; Amber99Sb-disp
  CT  CC  CW  NB    4     180.0      4.60240     2  ; Amber99Sb-disp
+ CT  CW  CC  NA    4     180.0      4.60240     2  ; Amber99Sb-disp
  CT  CC  CW  NA    4     180.0      4.60240     2  ; Amber99Sb-disp
  CB  CT  C*  CW    4     180.0      4.60240     2  ; Amber99Sb-disp
  CA  CA  CA  CT    4     180.0      4.60240     2  ; Amber99Sb-disp

--- a/Gromacs_FFs/a99SBdisp.ff/ffbonded.itp
+++ b/Gromacs_FFs/a99SBdisp.ff/ffbonded.itp
@@ -496,7 +496,7 @@
  CT  CV  CC  NA    4     180.0      4.60240     2  ; Amber99Sb-disp
  CT  CW  CC  NB    4     180.0      4.60240     2  ; Amber99Sb-disp
  CT  CC  CW  NB    4     180.0      4.60240     2  ; Amber99Sb-disp
- CT  CW  CC  NA    4     180.0      4.60240     2  ; Amber99Sb-disp
+ CT  CC  CW  NA    4     180.0      4.60240     2  ; Amber99Sb-disp
  CB  CT  C*  CW    4     180.0      4.60240     2  ; Amber99Sb-disp
  CA  CA  CA  CT    4     180.0      4.60240     2  ; Amber99Sb-disp
  C   CM  CM  CT    4     180.0      4.60240     2  ; Amber99Sb-disp


### PR DESCRIPTION
There was an error 
CT  CW CC NA
which should be
CT  CC  CW  NA
to match deshaw FF

This only seems to affect HIP, when HIP is used it will throw an error regarding a missing improper dihedral.