### PR TITLE
ffbonded: Added dihedral interaction

### DIFF
--- a/Gromacs_FFs/a99SBdisp.ff/ffbonded.itp
+++ b/Gromacs_FFs/a99SBdisp.ff/ffbonded.itp
@@ -494,6 +494,7 @@
  C   CM  N*  CT    4     180.0      4.18400     2  ; Amber99Sb-disp
  CT  O   C   OH    4     180.0     43.93200     2  ; Amber99Sb-disp
  CT  CV  CC  NA    4     180.0      4.60240     2  ; Amber99Sb-disp
+ CT  CC  CW  NA    4     180.0      4.60240     2  ; Amber99Sb-disp 
  CT  CW  CC  NB    4     180.0      4.60240     2  ; Amber99Sb-disp
  CT  CC  CW  NB    4     180.0      4.60240     2  ; Amber99Sb-disp
  CT  CW  CC  NA    4     180.0      4.60240     2  ; Amber99Sb-disp


### PR DESCRIPTION
Fixes #25.

Added the dihedral CT-CC-CW-NA because otherwise `pdb2gmx` fails for HIP (CT-CV-CC-NA was already present).

The attached zip file contains a PDB and an example of a `pdb2gmx` command that does not work without this fix.

[Hip_example.tar.gz](https://github.com/user-attachments/files/25015951/Hip_example.tar.gz)
